### PR TITLE
use https for images

### DIFF
--- a/cardgame.js
+++ b/cardgame.js
@@ -98,7 +98,7 @@ function buildDeck(data) {
             } else {
                 items[line.item.value] = {item: line.item.value, label: line.itemLabel.value, properties: {}};
                 if (line.image) {
-                    items[line.item.value].image = line.image.value;
+                    items[line.item.value].image = line.image.value.replace('http://', 'https://');
                 }else{
                     items[line.item.value].image = 'texture.png';
                 }


### PR DESCRIPTION
Many browsers warn about http content within https pages as mixed content.

commons.wikimedia.org does support https. I do not know about other possible image sources in Wikidata that are not supporting https.
All of the example topics worked fine for me.

As morr.cc always forwards to https the user has to have https available on the connection. There is no need to use //commons… then in order to let the browser decide.